### PR TITLE
"Super EX" Scoring

### DIFF
--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -129,6 +129,9 @@ end
 for index, label in ipairs(RadarCategories) do
 	if index == 1 then
 		text = nil
+		local textSuperEx = "S.EX"
+		local showSuperEX = true
+
 		if SL[pn].ActiveModifiers.ShowEXScore then
 			text = "ITG"
 		else
@@ -136,6 +139,8 @@ for index, label in ipairs(RadarCategories) do
 		end
 
 
+		-- @TODO - Marquee flip between ITG and S.EX scores
+		-- for now I'm essentially hardcoding the S.EX option
 		t[#t+1] = LoadFont(ThemePrefs.Get("ThemeFont") == "Common" and "Wendy/_wendy small"
 							or ThemePrefs.Get("ThemeFont") == "Mega" and "Mega/_mega font"
 							or ThemePrefs.Get("ThemeFont") == "Unprofessional" and "Unprofessional/_unprofessional small")..{
@@ -150,7 +155,26 @@ for index, label in ipairs(RadarCategories) do
 				else
 					self:diffuse( SL.JudgmentColors[SL.Global.GameMode][1] )
 				end
+				self:playcommand("Marquee")
+			end,
+			MarqueeCommand=function(self)
+				if not SL[pn].ActiveModifiers.ShowSuperEXScore or not SL[pn].ActiveModifiers.ShowEXScore then
+					return
+				end
+				if showSuperEX then
+					self:settext(textSuperEx)
+					self:diffuse(color('#FF00CC'))
+					self:x( (controller == PLAYER_1 and -145) or 105 )
+					showSuperEX = false
+				else
+					self:x( (controller == PLAYER_1 and -160) or 90 )
+					self:settext(text)
+					self:diffuse(Color.White)
+					showSuperEX = true
+				end
+				self:sleep(2):queuecommand("Marquee")
 			end
+
 		}
 	end
 

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentLabels.lua
@@ -139,8 +139,6 @@ for index, label in ipairs(RadarCategories) do
 		end
 
 
-		-- @TODO - Marquee flip between ITG and S.EX scores
-		-- for now I'm essentially hardcoding the S.EX option
 		t[#t+1] = LoadFont(ThemePrefs.Get("ThemeFont") == "Common" and "Wendy/_wendy small"
 							or ThemePrefs.Get("ThemeFont") == "Mega" and "Mega/_mega font"
 							or ThemePrefs.Get("ThemeFont") == "Unprofessional" and "Unprofessional/_unprofessional small")..{

--- a/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
+++ b/BGAnimations/ScreenEvaluation common/Panes/Pane2/JudgmentNumbers.lua
@@ -126,7 +126,6 @@ for index, RCType in ipairs(RadarCategories.Types) do
 	end
 
 	if index == 1 then
-		-- @TODO: Marquee flip between ITG and S.EX, currently hard-coding S.EX
 		local showSuperEX = true
 
 		t[#t+1] = LoadFont(ThemePrefs.Get("ThemeFont") .. " Bold")..{

--- a/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
+++ b/BGAnimations/ScreenGameplay overlay/TrackExScoreJudgments.lua
@@ -125,6 +125,7 @@ return Def.Actor{
 					Player=player, 
 					ExCounts=storage.ex_counts, 
 					ExScore=CalculateExScore(player,storage.ex_counts), 
+					SuperExScore=CalculateSuperExScore(player,storage.ex_counts),
 					actual_points=actual_points, 
 					actual_possible=actual_possible 
 				}

--- a/BGAnimations/ScreenGameplay underlay/PerPlayer/ScoreSuperEx.lua
+++ b/BGAnimations/ScreenGameplay underlay/PerPlayer/ScoreSuperEx.lua
@@ -1,0 +1,156 @@
+local player = ...
+local pn = ToEnumShortString(player)
+
+local mods = SL[pn].ActiveModifiers
+local IsUltraWide = (GetScreenAspectRatio() > 21/9)
+local NumPlayers = #GAMESTATE:GetHumanPlayers()
+local IsEX = SL[pn].ActiveModifiers.ShowEXScore
+local IsSuperEX = SL[pn].ActiveModifiers.ShowSuperEXScore
+
+if not IsSuperEX then return end
+
+-- -----------------------------------------------------------------------
+-- first, check for conditions where we might not draw the score actor at all
+
+if mods.HideScore then return end
+
+if NumPlayers > 1
+and mods.NPSGraphAtTop
+and not IsUltraWide
+then
+	return
+end
+
+-- -----------------------------------------------------------------------
+-- set up some preliminary variables and calculations for positioning and zooming
+
+local styletype = ToEnumShortString(GAMESTATE:GetCurrentStyle():GetStyleType())
+
+-- scores are not aligned symmetrically around screen.cx for aesthetic reasons
+-- and this is the cause of many code-induced headaches
+local pos = {
+	[PLAYER_1] = { x=(_screen.cx - clamp(_screen.w, 640, 854)/4.3),  y=56 },
+	[PLAYER_2] = { x=(_screen.cx + clamp(_screen.w, 640, 854)/4.3), y=56 },
+}
+
+local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(player)
+
+local StepsOrTrail = (GAMESTATE:IsCourseMode() and GAMESTATE:GetCurrentTrail(player)) or GAMESTATE:GetCurrentSteps(player)
+local total_tapnotes = StepsOrTrail:GetRadarValues(player):GetValue( "RadarCategory_Notes" )
+
+-- determine how many digits are needed to express the number of notes in base-10
+local digits = (math.floor(math.log10(total_tapnotes)) + 1)
+-- subtract 4 from the digit count; we're only really interested in how many digits past 4
+-- this stepcount is so we can use it to align the score actor in the StepStats pane if needed
+-- aligned-with-4-digits is the default
+digits = clamp(math.max(4, digits) - 4, 0, 3)
+
+local NoteFieldIsCentered = (GetNotefieldX(player) == _screen.cx)
+
+local ar_scale = {
+	sixteen_ten  = 0.825,
+	sixteen_nine = 1
+}
+local zoom_factor = clamp(scale(GetScreenAspectRatio(), 16/10, 16/9, ar_scale.sixteen_ten, ar_scale.sixteen_nine), 0, 1.125)
+
+-- -----------------------------------------------------------------------
+
+return LoadFont(ThemePrefs.Get("ThemeFont") .. " numbers")..{
+	Text="0.00",
+	Name=pn.."ScoreSuperEx",
+	InitCommand=function(self)
+		if player==PLAYER_1 then
+			self:valign(0):horizalign(left)
+		else
+			self:valign(0):horizalign(right)
+		end
+		self:zoom(0.25)
+		if IsEX then
+			-- If EX Score, let's diffuse it to be the same as the FA+ top window.
+			-- This will make it consistent with the EX Score Pane.
+			self:diffuse(color('#FF00CC'))
+		end
+	end,
+
+	BeginCommand=function(self)
+		-----------------------------------------------------------------
+		-- ultrawide with both players joined is really its own layout
+		-- hardcode some numbers for now, return early, and call it a day
+		-- until 21:9 displays become more popular
+		if IsUltraWide and #GAMESTATE:GetHumanPlayers() > 1 then
+			if player==PLAYER_1 then
+				self:x(134)
+			else
+				self:x(_screen.w - 4)
+			end
+
+			self:y( 238 )
+			return
+		end
+		-----------------------------------------------------------------
+
+		-- assume "normal" score positioning first, but there are many reasons it will need to be moved
+											
+		self:xy( pos[player].x, pos[player].y )
+
+		if mods.NPSGraphAtTop and styletype ~= "OnePlayerTwoSides" then
+			-- if NPSGraphAtTop and Step Statistics and not double,
+			-- move the score down into the stepstats pane under
+			-- the judgment breakdown
+			if mods.DataVisualizations=="Step Statistics" and false then
+				local step_stats = self:GetParent():GetChild("StepStatsPane"..pn)
+
+				-- Step Statistics might be true in the SL table from a previous game session
+				-- but current conditions might be such that it won't actually appear.
+				-- Ensure the StepStats ActorFrame is present before trying to traverse it.
+				if step_stats then
+					if player==PLAYER_1 then
+						if NoteFieldIsCentered then
+							self:x( pos[ OtherPlayer[player] ].x + SL_WideScale( 94, 112.5) )
+						else
+							self:x( pos[ OtherPlayer[player] ].x - SL_WideScale(-84, -60) )
+						end
+
+					-- PLAYER_2
+					else
+						if NoteFieldIsCentered then
+							self:x( pos[ OtherPlayer[player] ].x - 65.5 )
+						else
+							self:x( pos[ OtherPlayer[player] ].x - SL_WideScale(-6, -2))
+						end
+					end
+
+					self:y( 282 )
+				end
+
+			-- if NPSGraphAtTop but not Step Statistics
+			else
+				-- if not Center1Player, move the score right or left
+				-- within the normal gameplay header to where the
+				-- other player's score would be if this were versus
+				if not NoteFieldIsCentered then
+					self:x( pos[ OtherPlayer[player] ].x + 115 )
+					self:y( pos[ OtherPlayer[player] ].y )
+				end
+				-- if NoteFieldIsCentered, no need to move the score
+			end
+		end
+	end,
+	JudgmentMessageCommand=function(self)
+		self:queuecommand("RedrawScore")
+	end,
+	RedrawScoreCommand=function(self)
+		if not IsEX then
+			local dance_points = pss:GetPercentDancePoints()
+			local percent = FormatPercentScore( dance_points ):sub(1,-2)
+			self:settext(percent)
+		end
+	end,
+	ExCountsChangedMessageCommand=function(self, params)
+		if params.Player ~= player then return end
+
+		if IsEX then
+			self:settext(("%.02f"):format(params.SuperExScore))
+		end
+	end,
+}

--- a/BGAnimations/ScreenGameplay underlay/default.lua
+++ b/BGAnimations/ScreenGameplay underlay/default.lua
@@ -55,6 +55,7 @@ for player in ivalues(Players) do
 
 	t[#t+1] = LoadActor("./PerPlayer/UpperNPSGraph.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/Score.lua", player)
+	t[#t+1] = LoadActor("./PerPlayer/ScoreSuperEx.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/DifficultyMeter.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/LifeMeter/default.lua", player)
 	t[#t+1] = LoadActor("./PerPlayer/TargetScore/default.lua", player)

--- a/Languages/en.ini
+++ b/Languages/en.ini
@@ -1106,6 +1106,7 @@ Darkest=Darkest
 # FaPlus
 ShowFaPlusWindow=Display FA+ Window
 ShowEXScore=Display EX Score
+ShowSuperEXScore=Display S.EX Score
 ShowFaPlusPane=Display FA+ Pane
 SmallerWhite=10ms Blue Window
 

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -447,7 +447,7 @@ local Overrides = {
 				return { "ShowFaPlusWindow" }
 			end
 
-			return { "ShowFaPlusWindow", "ShowEXScore", "ShowFaPlusPane", "SmallerWhite" }
+			return { "ShowFaPlusWindow", "ShowEXScore", "ShowSuperEXScore", "ShowFaPlusPane", "SmallerWhite" }
 		end,
 		LoadSelections = function(self, list, pn)
 			local mods = SL[ToEnumShortString(pn)].ActiveModifiers
@@ -464,8 +464,9 @@ local Overrides = {
 
 			list[1] = mods.ShowFaPlusWindow or false
 			list[2] = mods.ShowEXScore or false
-			list[3] = mods.ShowFaPlusPane or false
-			list[4] = mods.SmallerWhite or false
+			list[3] = mods.ShowSuperEXScore or false
+			list[4] = mods.ShowFaPlusPane or false
+			list[5] = mods.SmallerWhite or false
 			return list
 		end,
 		SaveSelections = function(self, list, pn)
@@ -493,8 +494,9 @@ local Overrides = {
 
 			mods.ShowFaPlusWindow = list[1]
 			mods.ShowEXScore = list[2]
-			mods.ShowFaPlusPane = list[3]
-			mods.SmallerWhite = list[4]
+			mods.ShowSuperEXScore = list[3]
+			mods.ShowFaPlusPane = list[4]
+			mods.SmallerWhite = list[5]
 			-- Default to FA+ pane if either options are active.
 			sl_pn.EvalPanePrimary = ((list[1] or list[2]) and list[3]) and 2 or 1
 		end

--- a/Scripts/SL-PlayerProfiles.lua
+++ b/Scripts/SL-PlayerProfiles.lua
@@ -87,8 +87,9 @@ local permitted_profile_settings = {
 
 	ShowFaPlusWindow     = "boolean",
 	ShowEXScore          = "boolean",
+	ShowSuperEXScore     = "boolean",
 	ShowFaPlusPane       = "boolean",
-	SmallerWhite     = "boolean",
+	SmallerWhite     	 = "boolean",
 
 	HideEarlyDecentWayOffJudgments = "boolean",
 	HideEarlyDecentWayOffFlash     = "boolean",

--- a/Scripts/SL_Init.lua
+++ b/Scripts/SL_Init.lua
@@ -470,6 +470,18 @@ SL = {
 		Held=1,
 		HitMine=-1
 	},
+	SuperExWeights = {
+		W010=3.5,
+		W110=3,
+		W2=1,
+		W3=0,
+		W4=0,
+		W5=0,
+		Miss=0,
+		LetGo=0,
+		Held=1,
+		HitMine=-1
+	},
 	-- Fields used to determine whether or not we can connect to the
 	-- GrooveStats services.
 	GrooveStats = {

--- a/ThemeInfo.ini
+++ b/ThemeInfo.ini
@@ -1,4 +1,4 @@
 [ThemeInfo]
 DisplayName=Simply Love
 Author=teejusb
-Version=5.5.0 for ITGmania - 20241127 zmod
+Version=5.5.0 for ITGmania - 20240619 zmod


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/672124dd-02fb-464e-8245-e401ade5301e)
Quick vid demo: https://streamable.com/e61obr

Should work with common options for 1 player on either side, or 2 players. Probably has some jank otherwise. If anyone interested in trying it out just DM me and I can make sure it works with your settings. Otherwise if you want to see it in action I'll be playing with it for a bit.

Results screen flips between ITG and S.EX so no info is lost. Should sync up with the 10ms/15ms flips for the judgments.

Weights are 3.5/3/1/0/0/0/0, so greats no longer count for anything with this score, and excellents are a little more punishing. Then of course the only thing that counts for 3.5 is the 10ms blues.